### PR TITLE
[FIX] Si el resultado de un tp es null rompe el detalle

### DIFF
--- a/src/pages/app/TrabajosPracticos/Entrega.tsx
+++ b/src/pages/app/TrabajosPracticos/Entrega.tsx
@@ -101,7 +101,14 @@ export const Entrega: FC = () => {
           </Card.Subtitle>
         </div>
         <Card.Text as="code" className="pruebas">
-          <div dangerouslySetInnerHTML={{__html: convert.toHtml(resultado)}}></div>
+          {resultado && (
+            <div dangerouslySetInnerHTML={{__html: convert.toHtml(resultado)}}></div>
+          )}
+          {!resultado && (
+            <div>
+              Pendiente...
+            </div>
+          )}
         </Card.Text>
         <Card.Link
           href={archivo}


### PR DESCRIPTION
Problema:
- Cuando el campo resultado del detalle de un tp es null, la página de detalle del mismo queda en blanco.

Solución:
- Se chequea si el resultado es null antes de querer hacer el convert a html del mismo. Si lo es, en cambio, se muestra un "Pendiente...".