### PR TITLE
[FIX] No siempre se muestra el 404 de tron

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,14 +2,17 @@ import './custom.scss';
 import { Routes, Route } from 'react-router-dom';
 import Base from 'src/pages/app/Base';
 import Home from 'src/pages/app/Home';
-import TrabajosPracticos from 'src/pages/app/TrabajosPracticos';
+import {
+  TrabajosPracticos,
+  Entrega,
+} from 'src/pages/app/TrabajosPracticos';
 import Login from 'src/pages/auth/Login';
 import Examenes from 'src/pages/app/Examenes';
 import PasswordChange from 'src/pages/app/PasswordChange';
 import NotFound from 'src/pages/error/NotFound';
 import { AuthGuard, GuestGuard } from 'src/components/guards';
-import {SendRecoveryEmail} from 'src/pages/recovery/SendRecoveryEmail'; 
-import {PasswordReset} from './pages/recovery/PasswordReset';
+import { SendRecoveryEmail } from 'src/pages/recovery/SendRecoveryEmail';
+import { PasswordReset } from './pages/recovery/PasswordReset';
 
 function App() {
   return (
@@ -34,7 +37,8 @@ function App() {
       >
         <Route path="/" element={<Home/>}/>
         <Route path="home" element={<Home/>}/>
-        <Route path="trabajos-practicos/*" element={<TrabajosPracticos/>}/>
+        <Route path="trabajos-practicos/:id" element={<Entrega/>}/>
+        <Route path="trabajos-practicos" element={<TrabajosPracticos/>}/>
         <Route path="examenes" element={<Examenes/>}/>
         <Route path="password-change" element={<PasswordChange/>}/>
       </Route>

--- a/src/pages/app/TrabajosPracticos/Entrega.tsx
+++ b/src/pages/app/TrabajosPracticos/Entrega.tsx
@@ -16,6 +16,7 @@ import { EntregaDetailResponse } from 'src/types/tps';
 import { getEntregaDetail } from 'src/services/tps';
 import { formatDateWithHour } from 'src/utils/dates';
 import { tpsKeys } from 'src/pages/app/TrabajosPracticos/queries';
+import './styles.scss';
 
 type Error = {
   response: AxiosResponse<EntregaDetailResponse>;

--- a/src/pages/app/TrabajosPracticos/TrabajosPracticos.tsx
+++ b/src/pages/app/TrabajosPracticos/TrabajosPracticos.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import Stack from 'react-bootstrap/Stack';
 import NuevaEntrega from './components/NuevaEntrega';
 import Entregas from './components/Entregas';
+import './styles.scss';
 
 export const TrabajosPracticos: FC = () => {
   return (

--- a/src/pages/app/TrabajosPracticos/index.tsx
+++ b/src/pages/app/TrabajosPracticos/index.tsx
@@ -1,16 +1,2 @@
-import { FC } from 'react';
-import { Routes, Route } from 'react-router-dom';
-import Entrega from './Entrega';
-import TrabajosPracticos from './TrabajosPracticos';
-import './styles.scss';
-
-export const TrabajosPracticosRoutes: FC = () => {
-  return (
-    <Routes>
-      <Route path=":id" element={<Entrega/>}/>
-      <Route path="/" element={<TrabajosPracticos/>}/>
-    </Routes>
-  );
-};
-
-export default TrabajosPracticosRoutes;
+export { TrabajosPracticos } from './TrabajosPracticos';
+export { Entrega } from './Entrega';


### PR DESCRIPTION
Problema:
- En algunos paths inválidos no se muestra el 404 de tron. Esto pasaba por tener paths nesteados sin 404 interno. Ej: `trabajos-practicos/url/invalido`.

Solución:
- Se sacan las routes nesteadas y se las deja a todas en el mismo lugar, de esta forma todas agarran la misma página de 404 como default.