### PR TITLE
[FIX] Los minutos en la fecha de entrega se muestran mal

### DIFF
--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -1,9 +1,14 @@
 export const formatDateWithHour = (dateToFormat: string) => {
   const date = new Date(dateToFormat);
 
-  const localeDate = date.toLocaleDateString();
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
-
-  return `${localeDate} ${hours}:${minutes}`;
+  return date.toLocaleString(
+    'es',
+    {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    },
+  );
 };


### PR DESCRIPTION
Problema:
- Los minutos en la fecha de entrega, en el listado de entregas, se muestran con un formato inválido: dd/mm/aaaa hh:m (notar solo un lugar para el minuto).
- Lo mismo pasaba con el día y el mes: d/m/aaaa hh:m.

Solución:
- Se usa `toLocaleString` especificando el idioma español y que día, mes, hora y minuto deben ser de dos dígitos.