### PR TITLE
[FIX] Aparecen páginas inválidas en el paginado

### DIFF
--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -44,6 +44,7 @@ export const Pagination: FC<PaginationProps> = (props) => {
     if(total < max) {
       if(first > 1) {
         first -= (max - total);
+        first = first > 0 ? first : 1;
       }
       else if(last < totalPages) {
         last += (max - total);


### PR DESCRIPTION
Problema:
- Cuando se está en la página 4 de 4 aparece la página 0 para seleccionar.
- Si se va a la 0 aparece la página 5.

Solución:
- Se chequea que el first sea mayor a 0, sino se lo setteo en 1.