### PR TITLE
[FIX] Mostrar errores al fallar enviar entrega de tp

### DIFF
--- a/src/pages/app/TrabajosPracticos/components/NuevaEntrega/NuevaEntregaForm.tsx
+++ b/src/pages/app/TrabajosPracticos/components/NuevaEntrega/NuevaEntregaForm.tsx
@@ -4,13 +4,12 @@ import { useMutation } from '@tanstack/react-query';
 import Stack from 'react-bootstrap/Stack';
 import Form from 'react-bootstrap/Form';
 import LoadingButton from 'src/components/buttons/LoadingButton';
-import { getActiveInstances } from 'src/services/tps';
 import {
   Instance,
   CreateTPErrorResponse,
 } from 'src/types/tps';
 import { AxiosResponse } from 'axios';
-import { createTP } from 'src/services/tps';
+import { getActiveInstances, createTP } from 'src/services/tps';
 import { tpsKeys } from 'src/pages/app/TrabajosPracticos/queries';
 
 type Error = {
@@ -34,7 +33,13 @@ export const NuevaEntregaForm: FC = () => {
 
   const createMutation = useMutation<any, Error, any>(createTP);
 
-  const error = createMutation?.error?.response?.data?.non_field_errors[0];
+  const errorData = createMutation?.error?.response?.data;
+  const error = (
+    errorData?.non_field_errors ||
+    errorData?.archivo ||
+    errorData?.tp ||
+    ['Ocurrió un error inesperado']
+  )[0];
 
   useEffect(() => {
     let timer: NodeJS.Timeout | null = null;

--- a/src/types/tps.ts
+++ b/src/types/tps.ts
@@ -46,5 +46,7 @@ export type EntregasResponse = Pagination<PartialEntrega>;
 export type EntregaDetailResponse = Entrega;
 
 export type CreateTPErrorResponse = {
-  non_field_errors: [string];
+  non_field_errors?: [string];
+  archivo?: [string];
+  tp?: [string];
 };


### PR DESCRIPTION
Problema:
- Al fallar enviar entrega solo se muestra el error por:
  - Limite de entregas por horas. No se muestra el error correspondiente por:
  - Limite de tamaño.
  - TP no vigente.

Solución:
- Ahora se chequean los campos `archivo` y `tp` por posibles errores en la respuesta, además de `non_field_errors` que se estaba tomando anteriormente. Si ninguno de los tres tiene un mensaje se muestra un "Ocurrió un error inesperado".